### PR TITLE
Make Alt-drag moves transactional

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Hosted at https://arena-mux.michaelguidetti.info
 
 ## Development
 
+### Documentation
+- [Transactional Alt-drag moves](./docs/transactional-alt-move.md)
+
 ### Setup
 - Fork and clone this repo
 - Register an application with Are.na at https://dev.are.na/oauth/applications 

--- a/docs/transactional-alt-move.md
+++ b/docs/transactional-alt-move.md
@@ -1,0 +1,15 @@
+# Transactional Alt-Drag Moves
+
+Authored by GPT-5.5 in Cursor.
+
+Are.na Multiplexer lets users drag blocks between open channel windows. A normal drag copies the block by creating a new connection in the destination channel. Holding `Alt` changes that gesture into a move: the app should connect the block to the destination and disconnect it from the source as one coordinated operation.
+
+The client implements this with transaction-like semantics:
+
+- The destination window creates the new connection first and keeps the block in a pending state.
+- The source connection is deleted only after the destination connection exists.
+- The destination window commits the visible block only after both API operations succeed.
+- If deleting the source connection fails after the destination connection was created, the app compensates by deleting the new destination connection and removing the pending destination block.
+- The source window removes the original block only after the destination window dispatches the commit event.
+
+This is still a client-side transaction, not a server-side atomic transaction. If the compensating delete fails, Are.na may temporarily retain the newly created destination connection, and the client logs that rollback failure for debugging.

--- a/src/components/BlockContainer.tsx
+++ b/src/components/BlockContainer.tsx
@@ -15,6 +15,7 @@ export interface DraggingBlockData {
   block: ChannelContents,
   window: {
     id: number,
+    canDelete: boolean,
     view: ChannelWindowState['view'],
     scale: ChannelWindowState['scale']
   }
@@ -27,7 +28,7 @@ interface BlockContainerProps {
 
 function BlockContainer ({ data, children }: BlockContainerProps) {
   const { addChannelWindow } = useDesktopActionsContext()
-  const { blocks: windowBlocks, channel, view, scale, disconnectBlock } = useWindowContext()
+  const { blocks: windowBlocks, canDelete, channel, view, scale, disconnectBlock } = useWindowContext()
   const { open: openBlockViewer } = useBlockViewerActionsContext()
   const setDialog = useDialogActionsContext()
   const [isHovering, setIsHovering] = useState(false)
@@ -40,6 +41,7 @@ function BlockContainer ({ data, children }: BlockContainerProps) {
       block: { ...data },
       window: {
         id: channel.id,
+        canDelete,
         view,
         scale
       }

--- a/src/components/Window.tsx
+++ b/src/components/Window.tsx
@@ -24,6 +24,13 @@ export interface WindowProps {
 
 export type LoadingStatusState = 'inactive' | 'active' | 'waiting' | 'complete'
 
+const BLOCK_MOVE_COMMIT_EVENT = 'arena-multiplexer:block-move-commit'
+
+interface BlockMoveCommitEventDetail {
+  sourceChannelId: number,
+  blockId: number
+}
+
 function Window ({ path, data, data: { data: channel, scale, view } }: WindowProps) {
   const arena = useArena()
 
@@ -100,6 +107,22 @@ function Window ({ path, data, data: { data: channel, scale, view } }: WindowPro
     [blocks, canWrite, isLoading]
   )
 
+  useEffect(() => {
+    const handleBlockMoveCommit = (event: Event) => {
+      const { sourceChannelId, blockId } = (event as CustomEvent<BlockMoveCommitEventDetail>).detail
+
+      if (sourceChannelId === channel.id) {
+        dispatchBlocks({ type: 'remove', id: blockId })
+      }
+    }
+
+    globalThis.window.addEventListener(BLOCK_MOVE_COMMIT_EVENT, handleBlockMoveCommit)
+
+    return () => {
+      globalThis.window.removeEventListener(BLOCK_MOVE_COMMIT_EVENT, handleBlockMoveCommit)
+    }
+  }, [channel.id])
+
   // The draggingBlock state is needed in order to disable the droppable window
   // based off conditions in canDrop, which requires the block data as an
   // argument. This is needed to prevent blocks being disconnected when holding
@@ -139,12 +162,11 @@ function Window ({ path, data, data: { data: channel, scale, view } }: WindowPro
       // If this window is where the block was dropped...
       if (channel.id === over?.id) {
         if (canDrop(block)) {
-          connectBlock(block)
-        }
-        // If this window is the window the dropped block was dragged from...
-      } else if (over && channel.id === window.id) {
-        if (isHotkeyPressed('alt') && canDelete) {
-          disconnectBlock(block)
+          if (isHotkeyPressed('alt') && window.id !== channel.id) {
+            moveBlock(block, window)
+          } else {
+            connectBlock(block)
+          }
         }
       }
     },
@@ -153,6 +175,25 @@ function Window ({ path, data, data: { data: channel, scale, view } }: WindowPro
       setIsActiveDrop(false)
     }
   })
+
+  const createBlockConnection = useCallback(
+    async (block: ChannelContents) => {
+      const connectableType = block.type === 'Channel' ? 'Channel' : 'Block'
+      const result = await arena?.connections.create({
+        connectable_id: block.id,
+        connectable_type: connectableType,
+        channel_ids: [channel.id]
+      })
+      const newConnection = result?.data?.[0]
+
+      if (!newConnection) {
+        throw new Error('Block is missing new connection id')
+      }
+
+      return newConnection
+    },
+    [arena, channel.id]
+  )
 
   const connectBlock = useCallback(
     async (block: ChannelContents) => {
@@ -165,26 +206,76 @@ function Window ({ path, data, data: { data: channel, scale, view } }: WindowPro
       })
 
       try {
-        const connectableType = block.type === 'Channel' ? 'Channel' : 'Block'
-        const result = await arena?.connections.create({
-          connectable_id: block.id,
-          connectable_type: connectableType,
-          channel_ids: [channel.id]
-        })
-        const newConnection = result?.data?.[0]
+        const newConnection = await createBlockConnection(block)
 
-        if (newConnection) {
-          dispatchBlocks({
-            type: 'update',
-            block: { ...block, connection: newConnection }
-          })
-        }
+        dispatchBlocks({
+          type: 'update',
+          block: { ...block, connection: newConnection }
+        })
       } catch (error) {
         setError(getErrorMessage(error))
         dispatchBlocks({ type: 'remove', id: block.id })
       }
     },
-    [arena, canWrite, channel.id]
+    [canWrite, createBlockConnection]
+  )
+
+  const moveBlock = useCallback(
+    async (block: ChannelContents, sourceWindow: DraggingBlockData['window']) => {
+      if (!canWrite) return
+
+      const sourceConnectionId = block.connection?.id
+
+      if (!sourceWindow.canDelete) {
+        setError('You do not have permission to disconnect this block from the source channel')
+        return
+      }
+
+      if (!sourceConnectionId) {
+        setError('Block is missing source connection id')
+        return
+      }
+
+      dispatchBlocks({
+        type: 'append',
+        blocks: [{ ...block, connection: null }]
+      })
+
+      let targetConnectionId: number | null = null
+
+      try {
+        const newConnection = await createBlockConnection(block)
+        targetConnectionId = newConnection.id
+
+        await arena?.connections.delete(sourceConnectionId)
+
+        dispatchBlocks({
+          type: 'update',
+          block: { ...block, connection: newConnection }
+        })
+
+        globalThis.window.dispatchEvent(
+          new CustomEvent<BlockMoveCommitEventDetail>(BLOCK_MOVE_COMMIT_EVENT, {
+            detail: {
+              sourceChannelId: sourceWindow.id,
+              blockId: block.id
+            }
+          })
+        )
+      } catch (error) {
+        if (targetConnectionId) {
+          try {
+            await arena?.connections.delete(targetConnectionId)
+          } catch (rollbackError) {
+            console.error('Failed to roll back moved block connection', rollbackError)
+          }
+        }
+
+        setError(getErrorMessage(error))
+        dispatchBlocks({ type: 'remove', id: block.id })
+      }
+    },
+    [arena, canWrite, createBlockConnection]
   )
 
   const disconnectBlock = useCallback(


### PR DESCRIPTION
## Summary
- Coordinate Alt-drag moves from the destination window so the source block is only removed after the destination connection and source disconnect both succeed.
- Add rollback for partially-created destination connections when the source disconnect fails.
- Document the transaction-like behavior with explicit authorship by GPT-5.5 in Cursor.

## Test plan
- `yarn lint` (passes with one existing warning in `src/components/BlockViewer.tsx`)


Made with [Cursor](https://cursor.com)